### PR TITLE
Toolchain improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ You can report any of these in the Issues tab, and/or place your questions and s
 Head to the releases tab on the right and grab the version of the mod you want. Don't download the sources.jar file unless you want to add support to your mod. Make sure to install Coroutil to play with this mod.
 
 ##  How To Setup (Eclipse)
-- Requires coroutil-1.12.1-1.2.37 in libs folder (Create the folder in your project folder if it doesn't exist)
 - run "gradlew eclipse genEclipseRuns"
 
 *If you get an error when running the project like "Reference to undefined variable MC_VERSION", right click on the run.launch file -> Run As -> Run Configurations -> Environment -> and change "MC_VERSION" to 1.12.2.*

--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,18 @@ repositories
 		name = 'SpongePowered'
 		url = 'https://repo.spongepowered.org/repository/maven-public/'
    	}
+	maven
+	{
+		name = 'CurseMaven'
+		url = 'https://cursemaven.com'
+	}
 }
 
 dependencies
 {
 	minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
  	runtimeOnly fg.deobf("mezz.jei:jei_${minecraft_version}:${jei_version}")
- 	implementation files("libs/${coroutil_jar}")
+ 	implementation "curse.maven:coroutil-237749:${coroutil_version}"
 	implementation "org.spongepowered:mixin:0.8.5"
 	annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
 	testAnnotationProcessor "org.spongepowered:mixin:0.8.5:processor"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ minecraft_mappings_channel=stable
 minecraft_mappings_version=39-1.12
 forge_version=14.23.5.2860
 jei_version=4.16.1.302
+coroutil_version=2902920
 
 mod_version=2.9.10+hf3
 mod_group=net.mrbt0907.weather2
 mod_name=Weather2Remastered-1.12.2
-coroutil_jar=coroutil-1.12.1-1.2.37.jar
 
 client_directory=run
 server_directory=run (Server)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip


### PR DESCRIPTION
- Updated Gradle to version 7.6.6 for increased stability
- Handled CoroUtil dependency via CurseMaven, manual download and placement in `libs` folder is no longer required

Planning on providing some further fixes for the mod and figured to share this first for easier maintenance.